### PR TITLE
fix: 修复单图修改拖拽功能

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,6 +229,8 @@
             background: #f8f9fa;
             transition: all 0.3s ease;
             cursor: pointer;
+            position: relative;
+            z-index: 1;
         }
 
         .file-input-display:hover {
@@ -3513,50 +3515,7 @@
             document.body.removeChild(link);
         }
 
-        // 拖拽上传功能
-        const fileInputDisplay = document.querySelector('.file-input-display');
-        
-        fileInputDisplay.addEventListener('dragover', (e) => {
-            e.preventDefault();
-            fileInputDisplay.style.borderColor = '#764ba2';
-            fileInputDisplay.style.background = '#e9ecef';
-        });
-
-        fileInputDisplay.addEventListener('dragleave', (e) => {
-            e.preventDefault();
-            fileInputDisplay.style.borderColor = '#667eea';
-            fileInputDisplay.style.background = '#f8f9fa';
-        });
-
-        fileInputDisplay.addEventListener('drop', (e) => {
-            e.preventDefault();
-            fileInputDisplay.style.borderColor = '#667eea';
-            fileInputDisplay.style.background = '#f8f9fa';
-            
-            const files = e.dataTransfer.files;
-            if (files.length > 0 && files[0].type.startsWith('image/')) {
-                // 直接设置selectedFile而不依赖input.files
-                const file = files[0];
-                selectedFile = file;
-                const reader = new FileReader();
-                reader.onload = function(e) {
-                    document.getElementById('preview-img').src = e.target.result;
-                    document.getElementById('image-preview').style.display = 'block';
-                    document.getElementById('file-display-text').textContent = file.name;
-                    document.querySelector('.file-input-display').classList.add('has-file');
-                };
-                reader.readAsDataURL(file);
-                
-                // 尝试同时设置input.files用于兼容性
-                const fileInput = document.getElementById('source-image');
-                try {
-                    fileInput.files = files;
-                } catch(e) {
-                    // 某些浏览器不允许设置files属性，但selectedFile已经设置了
-                    console.log('Could not set input.files, but selectedFile is set');
-                }
-            }
-        });
+        // 旧的拖拽代码已移除，新的拖拽功能在DOMContentLoaded事件中实现
 
         // 多图上传相关变量
         let currentUploadMode = 'multiple'; // 固定为多图模式
@@ -4026,24 +3985,37 @@
             const singleImageDisplay = document.getElementById('single-image-display');
             
             if (singleImageDisplay) {
+                console.log('单图拖拽功能已初始化');
+                
                 singleImageDisplay.addEventListener('dragover', function(e) {
                     e.preventDefault();
+                    e.stopPropagation();
                     this.style.background = '#e9ecef';
+                    this.style.borderColor = '#764ba2';
+                    console.log('单图拖拽: dragover事件触发');
                 });
                 
                 singleImageDisplay.addEventListener('dragleave', function(e) {
                     e.preventDefault();
+                    e.stopPropagation();
                     this.style.background = '#f8f9fa';
+                    this.style.borderColor = '#667eea';
+                    console.log('单图拖拽: dragleave事件触发');
                 });
                 
                 singleImageDisplay.addEventListener('drop', function(e) {
                     e.preventDefault();
+                    e.stopPropagation();
                     this.style.background = '#f8f9fa';
+                    this.style.borderColor = '#667eea';
                     
+                    console.log('单图拖拽: drop事件触发');
                     const files = Array.from(e.dataTransfer.files).filter(file => file.type.startsWith('image/'));
+                    console.log('单图拖拽: 检测到文件数量:', files.length);
                     
                     if (files.length > 0) {
                         const file = files[0]; // 只取第一个文件
+                        console.log('单图拖拽: 处理文件:', file.name, file.type, file.size);
                         
                         // 验证文件
                         if (file.type !== 'image/jpeg' && file.type !== 'image/jpg' && file.type !== 'image/png') {
@@ -4059,8 +4031,11 @@
                         // 设置文件
                         selectedSingleFile = file;
                         updateSingleImagePreview();
+                        console.log('单图拖拽: 文件设置成功');
                     }
                 });
+            } else {
+                console.error('单图拖拽: 未找到single-image-display元素');
             }
         });
 


### PR DESCRIPTION
- 移除旧的拖拽代码，避免冲突
- 改进单图拖拽事件处理，添加调试信息
- 添加e.stopPropagation()防止事件冒泡
- 改进CSS样式，确保拖拽区域正确显示
- 添加详细的拖拽事件日志用于调试