### PR TITLE
fix: 修复保存历史记录到数据库的API调用

### DIFF
--- a/index.html
+++ b/index.html
@@ -2803,7 +2803,7 @@
             }
             
             try {
-                const response = await fetch('/api/user-history', {
+                const response = await fetch('/api/user-history-unified', {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
@@ -2842,7 +2842,7 @@
             try {
                 console.log('从后端API加载历史记录，用户ID:', currentUser.id);
                 
-                const response = await fetch('/api/user-history', {
+                const response = await fetch('/api/user-history-unified?simple=true', {
                     method: 'GET',
                     headers: {
                         'user-id': currentUser.id


### PR DESCRIPTION
- 修复saveHistoryToSupabase函数：从 /api/user-history 改为 /api/user-history-unified
- 修复loadHistoryFromSupabaseBackground函数：使用统一API
- 现在新生成的历史记录可以正确保存到Supabase数据库
- 解决历史记录只保存在本地不写入数据库的问题